### PR TITLE
Fix currency formatting across finance calculators

### DIFF
--- a/calculators/financial/compound-interest-calculator/calculator.js
+++ b/calculators/financial/compound-interest-calculator/calculator.js
@@ -1,7 +1,13 @@
 // calculator.js
 
 function formatCurrency(value) {
-  return '$' + parseFloat(value).toFixed(2).toLocaleString();
+  return (
+    '$' +
+    parseFloat(value).toLocaleString('en-US', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })
+  );
 }
 
 function calculateCompoundInterest() {

--- a/calculators/financial/savings-goal-calculator/calculator.js
+++ b/calculators/financial/savings-goal-calculator/calculator.js
@@ -1,7 +1,13 @@
 // calculator.js
 
 function formatCurrency(value) {
-  return '$' + parseFloat(value).toFixed(2).toLocaleString();
+  return (
+    '$' +
+    parseFloat(value).toLocaleString('en-US', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })
+  );
 }
 
 function calculateSavingsGoal() {

--- a/calculators/financial/simple-interest-calculator/calculator.js
+++ b/calculators/financial/simple-interest-calculator/calculator.js
@@ -1,7 +1,13 @@
 // calculator.js
 
 function formatCurrency(value) {
-  return '$' + parseFloat(value).toFixed(2).toLocaleString();
+  return (
+    '$' +
+    parseFloat(value).toLocaleString('en-US', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })
+  );
 }
 
 function calculateSimpleInterest() {


### PR DESCRIPTION
## Summary
- fix formatCurrency to properly localize numbers

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6845b36bab1c8329860ad469436809db