### PR TITLE
Update currency formatting for interest calculators

### DIFF
--- a/calculators/financial/compound-interest-calculator/calculator.js
+++ b/calculators/financial/compound-interest-calculator/calculator.js
@@ -1,7 +1,11 @@
 // calculator.js
 
 function formatCurrency(value) {
-  return '$' + parseFloat(value).toFixed(2).toLocaleString();
+  return '$' +
+    Number(value).toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2
+    });
 }
 
 function calculateCompoundInterest() {

--- a/calculators/financial/simple-interest-calculator/calculator.js
+++ b/calculators/financial/simple-interest-calculator/calculator.js
@@ -1,7 +1,11 @@
 // calculator.js
 
 function formatCurrency(value) {
-  return '$' + parseFloat(value).toFixed(2).toLocaleString();
+  return '$' +
+    Number(value).toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2
+    });
 }
 
 function calculateSimpleInterest() {


### PR DESCRIPTION
## Summary
- update `formatCurrency` in both interest calculators for proper thousands separators and fixed decimals

## Testing
- `

------
https://chatgpt.com/codex/tasks/task_e_6845b488a27883299d16b2887ec1e526