### PR TITLE
Fix simple interest page metadata

### DIFF
--- a/calculators/financial/simple-interest-calculator/index.html
+++ b/calculators/financial/simple-interest-calculator/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Simple Interest Calculator | Free & Accurate</title>
-  <meta name="description" content="Calculate compound interest instantly with our free online calculator. Accurate, real-time results with graphs and mobile support." />
+  <meta name="description" content="Calculate simple interest instantly with our free online calculator. Accurate, real-time results with graphs and mobile support." />
   <meta property="og:title" content="Simple Interest Calculator" />
-  <meta property="og:description" content="Free online compound interest calculator. Fast, accurate, and mobile-friendly." />
+  <meta property="og:description" content="Free online simple interest calculator. Fast, accurate, and mobile-friendly." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://calculatorchoice.com/calculators/simple-interest/" />
   <meta property="og:image" content="https://calculatorchoice.com/assets/simple-interest-preview.png" />
@@ -17,7 +17,7 @@
     "@context": "https://schema.org",
     "@type": "Calculator",
     "name": "Simple Interest Calculator",
-    "description": "Free online tool to calculate compound interest over time with real-time results.",
+    "description": "Free online tool to calculate simple interest over time with real-time results.",
     "url": "https://calculatorchoice.com/calculators/simple-interest/"
   }
   </script>
@@ -31,7 +31,7 @@
   <main>
     <section class="calculator-container">
       <h1>Simple Interest Calculator</h1>
-      <p>Instantly calculate your future investment value with compound interest.</p>
+      <p>Instantly calculate your future investment value with simple interest.</p>
 
       <div class="input-group">
         <label for="principal">Principal Amount ($):</label>


### PR DESCRIPTION
## Summary
- update the page description to talk about simple interest instead of compound interest
- adjust Open Graph and JSON-LD descriptions accordingly
- tweak the introduction text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845b487cf6c83299cecae3ad4b9c5ac