### PR TITLE
Add additional calculators for physics, electronics and health

### DIFF
--- a/calculators.json
+++ b/calculators.json
@@ -1,0 +1,88 @@
+{
+  "categories": [
+    {
+      "slug": "engineering",
+      "title": "Engineering",
+      "calculators": [
+        {
+          "id": "beam-deflection",
+          "title": "Beam Deflection Calculator",
+          "inputs": [
+            {"name": "load", "label": "Load (N)", "type": "number"},
+            {"name": "length", "label": "Length (m)", "type": "number"},
+            {"name": "modulus", "label": "Elastic Modulus (Pa)", "type": "number"},
+            {"name": "inertia", "label": "Moment of Inertia (m^4)", "type": "number"}
+          ],
+          "compute": "(load * Math.pow(length,3)) / (48 * modulus * inertia)"
+        }
+      ]
+    },
+    {
+      "slug": "astronomy",
+      "title": "Astronomy",
+      "calculators": [
+        {
+          "id": "escape-velocity",
+          "title": "Escape Velocity Calculator",
+          "inputs": [
+            {"name": "mass", "label": "Mass of Body (kg)", "type": "number"},
+            {"name": "radius", "label": "Radius (m)", "type": "number"}
+          ],
+          "compute": "Math.sqrt(2 * 6.67430e-11 * mass / radius)"
+        }
+      ]
+    },
+    {
+      "slug": "physics",
+      "title": "Physics",
+      "calculators": [
+        {
+          "id": "projectile-range",
+          "title": "Projectile Range Calculator",
+          "inputs": [
+            {"name": "velocity", "label": "Initial Velocity (m/s)", "type": "number"},
+            {"name": "angle", "label": "Launch Angle (degrees)", "type": "number"}
+          ],
+          "compute": "(Math.pow(velocity,2) * Math.sin(2 * angle * Math.PI / 180)) / 9.81"
+        },
+        {
+          "id": "pendulum-period",
+          "title": "Simple Pendulum Period Calculator",
+          "inputs": [
+            {"name": "length", "label": "Length (m)", "type": "number"}
+          ],
+          "compute": "2 * Math.PI * Math.sqrt(length / 9.81)"
+        }
+      ]
+    },
+    {
+      "slug": "electronics",
+      "title": "Electronics",
+      "calculators": [
+        {
+          "id": "ohms-law",
+          "title": "Ohm's Law Calculator",
+          "inputs": [
+            {"name": "voltage", "label": "Voltage (V)", "type": "number"},
+            {"name": "resistance", "label": "Resistance (Ω)", "type": "number"}
+          ],
+          "compute": "voltage / resistance"
+        }
+      ]
+    },
+    {
+      "slug": "health",
+      "title": "Health",
+      "calculators": [
+        {
+          "id": "water-intake",
+          "title": "Daily Water Intake Calculator",
+          "inputs": [
+            {"name": "weight", "label": "Body Weight (kg)", "type": "number"}
+          ],
+          "compute": "weight * 0.033"
+        }
+      ]
+    }
+  ]
+}

--- a/calculators/astronomy/escape-velocity/calculator.js
+++ b/calculators/astronomy/escape-velocity/calculator.js
@@ -1,0 +1,7 @@
+document.getElementById('calc-form').addEventListener('submit', function(e) {
+  e.preventDefault();
+  const mass = parseFloat(document.getElementById('mass').value);
+  const radius = parseFloat(document.getElementById('radius').value);
+  const result = Math.sqrt(2 * 6.67430e-11 * mass / radius);
+  document.getElementById('result').textContent = result;
+});

--- a/calculators/astronomy/escape-velocity/index.html
+++ b/calculators/astronomy/escape-velocity/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+  <title>Escape Velocity Calculator</title>
+  <link rel='stylesheet' href='../../style.css'>
+  <script defer src='calculator.js'></script>
+</head>
+<body>
+  <h1>Escape Velocity Calculator</h1>
+  <form id='calc-form'>
+    <label>Mass of Body (kg): <input type='number' id='mass' name='mass' required></label><br>
+    <label>Radius (m): <input type='number' id='radius' name='radius' required></label><br>
+    <button type='submit'>Calculate</button>
+  </form>
+  <div id='result'></div>
+</body>
+</html>

--- a/calculators/astronomy/escape-velocity/style.css
+++ b/calculators/astronomy/escape-velocity/style.css
@@ -1,0 +1,1 @@
+/* Uses global styles */

--- a/calculators/electronics/ohms-law/calculator.js
+++ b/calculators/electronics/ohms-law/calculator.js
@@ -1,0 +1,7 @@
+document.getElementById('calc-form').addEventListener('submit', function(e) {
+  e.preventDefault();
+  const voltage = parseFloat(document.getElementById('voltage').value);
+  const resistance = parseFloat(document.getElementById('resistance').value);
+  const result = voltage / resistance;
+  document.getElementById('result').textContent = result;
+});

--- a/calculators/electronics/ohms-law/index.html
+++ b/calculators/electronics/ohms-law/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+  <title>Ohm's Law Calculator</title>
+  <link rel='stylesheet' href='../../style.css'>
+  <script defer src='calculator.js'></script>
+</head>
+<body>
+  <h1>Ohm's Law Calculator</h1>
+  <form id='calc-form'>
+    <label>Voltage (V): <input type='number' id='voltage' name='voltage' required></label><br>
+    <label>Resistance (Ω): <input type='number' id='resistance' name='resistance' required></label><br>
+    <button type='submit'>Calculate</button>
+  </form>
+  <div id='result'></div>
+</body>
+</html>

--- a/calculators/electronics/ohms-law/style.css
+++ b/calculators/electronics/ohms-law/style.css
@@ -1,0 +1,1 @@
+/* Uses global styles */

--- a/calculators/engineering/beam-deflection/calculator.js
+++ b/calculators/engineering/beam-deflection/calculator.js
@@ -1,0 +1,9 @@
+document.getElementById('calc-form').addEventListener('submit', function(e) {
+  e.preventDefault();
+  const load = parseFloat(document.getElementById('load').value);
+  const length = parseFloat(document.getElementById('length').value);
+  const modulus = parseFloat(document.getElementById('modulus').value);
+  const inertia = parseFloat(document.getElementById('inertia').value);
+  const result = (load * Math.pow(length,3)) / (48 * modulus * inertia);
+  document.getElementById('result').textContent = result;
+});

--- a/calculators/engineering/beam-deflection/index.html
+++ b/calculators/engineering/beam-deflection/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+  <title>Beam Deflection Calculator</title>
+  <link rel='stylesheet' href='../../style.css'>
+  <script defer src='calculator.js'></script>
+</head>
+<body>
+  <h1>Beam Deflection Calculator</h1>
+  <form id='calc-form'>
+    <label>Load (N): <input type='number' id='load' name='load' required></label><br>
+    <label>Length (m): <input type='number' id='length' name='length' required></label><br>
+    <label>Elastic Modulus (Pa): <input type='number' id='modulus' name='modulus' required></label><br>
+    <label>Moment of Inertia (m^4): <input type='number' id='inertia' name='inertia' required></label><br>
+    <button type='submit'>Calculate</button>
+  </form>
+  <div id='result'></div>
+</body>
+</html>

--- a/calculators/engineering/beam-deflection/style.css
+++ b/calculators/engineering/beam-deflection/style.css
@@ -1,0 +1,1 @@
+/* Uses global styles */

--- a/calculators/health/water-intake/calculator.js
+++ b/calculators/health/water-intake/calculator.js
@@ -1,0 +1,6 @@
+document.getElementById('calc-form').addEventListener('submit', function(e) {
+  e.preventDefault();
+  const weight = parseFloat(document.getElementById('weight').value);
+  const result = weight * 0.033;
+  document.getElementById('result').textContent = result;
+});

--- a/calculators/health/water-intake/index.html
+++ b/calculators/health/water-intake/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+  <title>Daily Water Intake Calculator</title>
+  <link rel='stylesheet' href='../../style.css'>
+  <script defer src='calculator.js'></script>
+</head>
+<body>
+  <h1>Daily Water Intake Calculator</h1>
+  <form id='calc-form'>
+    <label>Body Weight (kg): <input type='number' id='weight' name='weight' required></label><br>
+    <button type='submit'>Calculate</button>
+  </form>
+  <div id='result'></div>
+</body>
+</html>

--- a/calculators/health/water-intake/style.css
+++ b/calculators/health/water-intake/style.css
@@ -1,0 +1,1 @@
+/* Uses global styles */

--- a/calculators/physics/pendulum-period/calculator.js
+++ b/calculators/physics/pendulum-period/calculator.js
@@ -1,0 +1,6 @@
+document.getElementById('calc-form').addEventListener('submit', function(e) {
+  e.preventDefault();
+  const length = parseFloat(document.getElementById('length').value);
+  const result = 2 * Math.PI * Math.sqrt(length / 9.81);
+  document.getElementById('result').textContent = result;
+});

--- a/calculators/physics/pendulum-period/index.html
+++ b/calculators/physics/pendulum-period/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+  <title>Simple Pendulum Period Calculator</title>
+  <link rel='stylesheet' href='../../style.css'>
+  <script defer src='calculator.js'></script>
+</head>
+<body>
+  <h1>Simple Pendulum Period Calculator</h1>
+  <form id='calc-form'>
+    <label>Length (m): <input type='number' id='length' name='length' required></label><br>
+    <button type='submit'>Calculate</button>
+  </form>
+  <div id='result'></div>
+</body>
+</html>

--- a/calculators/physics/pendulum-period/style.css
+++ b/calculators/physics/pendulum-period/style.css
@@ -1,0 +1,1 @@
+/* Uses global styles */

--- a/calculators/physics/projectile-range/calculator.js
+++ b/calculators/physics/projectile-range/calculator.js
@@ -1,0 +1,7 @@
+document.getElementById('calc-form').addEventListener('submit', function(e) {
+  e.preventDefault();
+  const velocity = parseFloat(document.getElementById('velocity').value);
+  const angle = parseFloat(document.getElementById('angle').value);
+  const result = (Math.pow(velocity,2) * Math.sin(2 * angle * Math.PI / 180)) / 9.81;
+  document.getElementById('result').textContent = result;
+});

--- a/calculators/physics/projectile-range/index.html
+++ b/calculators/physics/projectile-range/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+  <title>Projectile Range Calculator</title>
+  <link rel='stylesheet' href='../../style.css'>
+  <script defer src='calculator.js'></script>
+</head>
+<body>
+  <h1>Projectile Range Calculator</h1>
+  <form id='calc-form'>
+    <label>Initial Velocity (m/s): <input type='number' id='velocity' name='velocity' required></label><br>
+    <label>Launch Angle (degrees): <input type='number' id='angle' name='angle' required></label><br>
+    <button type='submit'>Calculate</button>
+  </form>
+  <div id='result'></div>
+</body>
+</html>

--- a/calculators/physics/projectile-range/style.css
+++ b/calculators/physics/projectile-range/style.css
@@ -1,0 +1,1 @@
+/* Uses global styles */

--- a/generate_calculators.py
+++ b/generate_calculators.py
@@ -1,0 +1,50 @@
+import json
+import os
+
+SPEC_FILE = 'calculators.json'
+
+with open(SPEC_FILE) as f:
+    data = json.load(f)
+
+for category in data.get('categories', []):
+    cat_dir = os.path.join('calculators', category['slug'])
+    os.makedirs(cat_dir, exist_ok=True)
+    for calc in category.get('calculators', []):
+        calc_dir = os.path.join(cat_dir, calc['id'])
+        os.makedirs(calc_dir, exist_ok=True)
+
+        html_path = os.path.join(calc_dir, 'index.html')
+        if not os.path.exists(html_path):
+            with open(html_path, 'w') as f:
+                f.write(f"""<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+  <title>{calc['title']}</title>
+  <link rel='stylesheet' href='../../style.css'>
+  <script defer src='calculator.js'></script>
+</head>
+<body>
+  <h1>{calc['title']}</h1>
+  <form id='calc-form'>
+""")
+                for inp in calc['inputs']:
+                    f.write(f"    <label>{inp['label']}: <input type='{inp['type']}' id='{inp['name']}' name='{inp['name']}' required></label><br>\n")
+                f.write("    <button type='submit'>Calculate</button>\n  </form>\n  <div id='result'></div>\n</body>\n</html>")
+
+        js_path = os.path.join(calc_dir, 'calculator.js')
+        if not os.path.exists(js_path):
+            with open(js_path, 'w') as f:
+                f.write("document.getElementById('calc-form').addEventListener('submit', function(e) {\n")
+                f.write("  e.preventDefault();\n")
+                for inp in calc['inputs']:
+                    f.write(f"  const {inp['name']} = parseFloat(document.getElementById('{inp['name']}').value);\n")
+                f.write(f"  const result = {calc['compute']};\n")
+                f.write("  document.getElementById('result').textContent = result;\n")
+                f.write("});\n")
+
+        css_path = os.path.join(calc_dir, 'style.css')
+        if not os.path.exists(css_path):
+            with open(css_path, 'w') as f:
+                f.write("/* Uses global styles */\n")


### PR DESCRIPTION
## Summary
- extend `calculators.json` with new Physics, Electronics and Health categories
- generate corresponding calculator pages using `generate_calculators.py`
- add calculators for Projectile Range, Pendulum Period, Ohm's Law and Daily Water Intake

## Testing
- `python3 generate_calculators.py`
- `python3 -m py_compile generate_calculators.py`


------
https://chatgpt.com/codex/tasks/task_e_6845c12fa83c832997dee5331a45c0a5