### PR TITLE
Fix calculator metadata and home page links

### DIFF
--- a/calculators/education/exam-score-needed/index.html
+++ b/calculators/education/exam-score-needed/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><TITLE HERE></title>
-  <meta name="description" content="<META DESCRIPTION HERE>">
+  <title>Exam Score Needed Calculator – Calculator Choice</title>
+  <meta name="description" content="Free online Exam Score Needed Calculator to compute results instantly.">
   <link rel="stylesheet" href="style.css">
   <script defer src="calculator.js"></script>
 </head>

--- a/calculators/education/final-grade-calculator/index.html
+++ b/calculators/education/final-grade-calculator/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><TITLE HERE></title>
-  <meta name="description" content="<META DESCRIPTION HERE>">
+  <title>Final Grade Calculator – Calculator Choice</title>
+  <meta name="description" content="Free online Final Grade Calculator to compute results instantly.">
   <meta name="keywords" content="final grade calculator, what do I need on my final, final exam calculator">
   <link rel="stylesheet" href="style.css">
   <script defer src="calculator.js"></script>

--- a/calculators/education/gpa-calculator/index.html
+++ b/calculators/education/gpa-calculator/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><TITLE HERE></title>
-  <meta name="description" content="<META DESCRIPTION HERE>">
+  <title>GPA Calculator – Calculator Choice</title>
+  <meta name="description" content="Free online GPA Calculator to compute results instantly.">
   <meta name="keywords" content="gpa calculator, college gpa calculator, high school gpa, grade point average calculator">
   <link rel="stylesheet" href="style.css">
   <script defer src="calculator.js"></script>

--- a/calculators/education/grade-percentage-calculator/index.html
+++ b/calculators/education/grade-percentage-calculator/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><TITLE HERE></title>
-  <meta name="description" content="<META DESCRIPTION HERE>">
+  <title>Grade Percentage Calculator – Calculator Choice</title>
+  <meta name="description" content="Free online Grade Percentage Calculator to compute results instantly.">
   <meta name="keywords" content="grade percentage calculator, calculate grade, score to percentage">
   <link rel="stylesheet" href="style.css">
   <script defer src="calculator.js"></script>

--- a/calculators/education/study-time-calculator/index.html
+++ b/calculators/education/study-time-calculator/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><TITLE HERE></title>
-  <meta name="description" content="<META DESCRIPTION HERE>">
+  <title>Study Time Calculator – Calculator Choice</title>
+  <meta name="description" content="Free online Study Time Calculator to compute results instantly.">
   <meta name="keywords" content="study time calculator, weekly study hours, college study planner">
   <link rel="stylesheet" href="style.css">
   <script defer src="calculator.js"></script>

--- a/calculators/fitness/bmr-calculator/index.html
+++ b/calculators/fitness/bmr-calculator/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><TITLE HERE></title>
-  <meta name="description" content="<META DESCRIPTION HERE>">
+  <title>BMR Calculator – Calculator Choice</title>
+  <meta name="description" content="Free online BMR Calculator to compute results instantly.">
   <link rel="stylesheet" href="style.css">
   <script defer src="calculator.js"></script>
 </head>

--- a/calculators/fitness/ideal-weight-calculator/index.html
+++ b/calculators/fitness/ideal-weight-calculator/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><TITLE HERE></title>
-  <meta name="description" content="<META DESCRIPTION HERE>">
+  <title>Ideal Weight Calculator – Calculator Choice</title>
+  <meta name="description" content="Free online Ideal Weight Calculator to compute results instantly.">
   <link rel="stylesheet" href="style.css">
   <script defer src="calculator.js"></script>
 </head>

--- a/calculators/math/average-calculator/index.html
+++ b/calculators/math/average-calculator/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><TITLE HERE></title>
-  <meta name="description" content="<META DESCRIPTION HERE>">
+  <title>Average Calculator – Calculator Choice</title>
+  <meta name="description" content="Free online Average Calculator to compute results instantly.">
   <link rel="stylesheet" href="style.css">
   <script defer src="calculator.js"></script>
 </head>

--- a/calculators/math/decimal-to-fraction/index.html
+++ b/calculators/math/decimal-to-fraction/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><TITLE HERE></title>
-  <meta name="description" content="<META DESCRIPTION HERE>">
+  <title>Decimal to Fraction Converter – Calculator Choice</title>
+  <meta name="description" content="Free online Decimal to Fraction Converter to compute results instantly.">
   <link rel="stylesheet" href="style.css">
   <script defer src="calculator.js"></script>
 </head>

--- a/calculators/math/fraction-calculator/index.html
+++ b/calculators/math/fraction-calculator/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><TITLE HERE></title>
-  <meta name="description" content="<META DESCRIPTION HERE>">
+  <title>Fraction Calculator – Calculator Choice</title>
+  <meta name="description" content="Free online Fraction Calculator to compute results instantly.">
   <link rel="stylesheet" href="style.css">
   <script defer src="calculator.js"></script>
 </head>

--- a/calculators/math/percentage-calculator/index.html
+++ b/calculators/math/percentage-calculator/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><TITLE HERE></title>
-  <meta name="description" content="<META DESCRIPTION HERE>">
+  <title>Percentage Calculator – Calculator Choice</title>
+  <meta name="description" content="Free online Percentage Calculator to compute results instantly.">
   <link rel="stylesheet" href="style.css">
   <script defer src="calculator.js"></script>
 </head>

--- a/calculators/misc/height-calculator/height-calculator-v2/index.html
+++ b/calculators/misc/height-calculator/height-calculator-v2/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title><TITLE HERE></title>
-  <meta name="description" content="<META DESCRIPTION HERE>" />
+  <title>Height Calculator from Parents – Calculator Choice</title>
+  <meta name="description" content="Free online Height Calculator from Parents to compute results instantly." />
   <meta name="keywords" content="height calculator from parents, adult height predictor, calculate height using genetics" />
   <link rel="stylesheet" href="style.css" />
   <script defer src="calculator.js"></script>

--- a/calculators/parenting/baby-feeding-calculator/index.html
+++ b/calculators/parenting/baby-feeding-calculator/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><TITLE HERE></title>
-  <meta name="description" content="<META DESCRIPTION HERE>">
+  <title>Baby Feed Calculator – Calculator Choice</title>
+  <meta name="description" content="Free online Baby Feed Calculator to compute results instantly.">
   <meta name="keywords" content="baby feed calculator, newborn milk intake, infant daily feeding amount">
   <link rel="stylesheet" href="style.css">
   <script defer src="calculator.js"></script>

--- a/calculators/parenting/baby-growth-chart/index.html
+++ b/calculators/parenting/baby-growth-chart/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><TITLE HERE></title>
-  <meta name="description" content="<META DESCRIPTION HERE>">
+  <title>Baby Growth Chart Calculator – Calculator Choice</title>
+  <meta name="description" content="Free online Baby Growth Chart Calculator to compute results instantly.">
   <meta name="keywords" content="baby growth chart calculator, percentile calculator baby, infant weight percentile, baby height percentile">
   <link rel="stylesheet" href="style.css">
   <script defer src="calculator.js"></script>

--- a/calculators/parenting/child-bmi-calculator/index.html
+++ b/calculators/parenting/child-bmi-calculator/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><TITLE HERE></title>
-  <meta name="description" content="<META DESCRIPTION HERE>">
+  <title>Child BMI Calculator – Calculator Choice</title>
+  <meta name="description" content="Free online Child BMI Calculator to compute results instantly.">
   <meta name="keywords" content="child bmi calculator, bmi percentile child, bmi for kids calculator">
   <link rel="stylesheet" href="style.css">
   <script defer src="calculator.js"></script>

--- a/calculators/parenting/due-date-calculator/index.html
+++ b/calculators/parenting/due-date-calculator/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><TITLE HERE></title>
-  <meta name="description" content="<META DESCRIPTION HERE>">
+  <title>Due Date Calculator – Calculator Choice</title>
+  <meta name="description" content="Free online Due Date Calculator to compute results instantly.">
   <meta name="keywords" content="due date calculator, pregnancy calculator, lmp due date estimator">
   <link rel="stylesheet" href="style.css">
   <script defer src="calculator.js"></script>

--- a/calculators/parenting/nap-schedule-calculator/index.html
+++ b/calculators/parenting/nap-schedule-calculator/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><TITLE HERE></title>
-  <meta name="description" content="<META DESCRIPTION HERE>">
+  <title>Baby Nap Schedule Calculator – Calculator Choice</title>
+  <meta name="description" content="Free online Baby Nap Schedule Calculator to compute results instantly.">
   <meta name="keywords" content="baby nap schedule, nap calculator, baby sleep schedule by age">
   <link rel="stylesheet" href="style.css">
   <script defer src="calculator.js"></script>

--- a/index.html
+++ b/index.html
@@ -22,13 +22,19 @@
         <li><a href="#education">Education</a></li>
         <li><a href="#chemistry">Chemistry</a></li>
         <li><a href="#parenting">Parenting</a></li>
+        <li><a href="#astronomy">Astronomy</a></li>
+        <li><a href="#electronics">Electronics</a></li>
+        <li><a href="#engineering">Engineering</a></li>
+        <li><a href="#health">Health</a></li>
+        <li><a href="#physics">Physics</a></li>
+        <li><a href="#graphing">Graphing</a></li>
       </ul>
     </nav>
   </header>
   <section class="hero">
     <h1>Trusted Calculators for Real Life</h1>
     <p>Your hub for quick and reliable answers.</p>
-    <input class="search" type="text" placeholder="Search 25+ calculators…" />
+    <input class="search" type="text" placeholder="Search 40+ calculators…" />
     <a class="cta" href="#financial">Browse All Calculators</a>
   </section>
   <main class="category-sections">
@@ -83,6 +89,48 @@
       <h2>Misc Calculators</h2>
       <div class="calculator-grid">
         <a class="card" href="calculators/misc/height-calculator/">Height Calculator</a>
+      </div>
+    </section>
+
+    <section id="astronomy">
+      <h2>Astronomy Calculators</h2>
+      <div class="calculator-grid">
+        <a class="card" href="calculators/astronomy/escape-velocity/">Escape Velocity Calculator</a>
+      </div>
+    </section>
+
+    <section id="electronics">
+      <h2>Electronics Calculators</h2>
+      <div class="calculator-grid">
+        <a class="card" href="calculators/electronics/ohms-law/">Ohm's Law Calculator</a>
+      </div>
+    </section>
+
+    <section id="engineering">
+      <h2>Engineering Calculators</h2>
+      <div class="calculator-grid">
+        <a class="card" href="calculators/engineering/beam-deflection/">Beam Deflection Calculator</a>
+      </div>
+    </section>
+
+    <section id="health">
+      <h2>Health Calculators</h2>
+      <div class="calculator-grid">
+        <a class="card" href="calculators/health/water-intake/">Daily Water Intake Calculator</a>
+      </div>
+    </section>
+
+    <section id="physics">
+      <h2>Physics Calculators</h2>
+      <div class="calculator-grid">
+        <a class="card" href="calculators/physics/projectile-range/">Projectile Range Calculator</a><a class="card" href="calculators/physics/pendulum-period/">Simple Pendulum Period</a>
+      </div>
+    </section>
+
+    <section id="graphing">
+      <h2>Graphing Tools</h2>
+      <div class="calculator-grid">
+        <a class="card" href="calculators/graphingcalculator/">Interactive Graphing Calculator</a>
       </div>
     </section>
     

--- a/style.css
+++ b/style.css
@@ -1,13 +1,13 @@
 
 :root {
-  --accent-color: #007bff;
-  --accent-light: #ebf4ff;
+  --accent-color: #6a0dad;
+  --accent-light: #f3e8ff;
 }
 
 body {
   margin: 0;
   font-family: 'Inter', sans-serif;
-  background: linear-gradient(to bottom, #fdfbfb, #ebedee);
+  background: linear-gradient(to bottom, #ffffff, #f1f5ff);
   color: #333;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- fill in missing titles and descriptions for calculators
- update theme colors
- list all calculator sections on home page

## Testing
- `python -m py_compile generate_calculators.py`


------
https://chatgpt.com/codex/tasks/task_e_6845cc62fd688329a259901ea99765f5